### PR TITLE
fixes the incorrect version of vertical-stack-in-card

### DIFF
--- a/repos.json
+++ b/repos.json
@@ -317,8 +317,8 @@
     "vertical-stack-in-card": {
         "changelog": "https://github.com/custom-cards/vertical-stack-in-card",
         "remote_location": "https://raw.githubusercontent.com/custom-cards/vertical-stack-in-card/master/vertical-stack-in-card.js",
-        "updated_at": "2019-01-08",
-        "version": "v0.0.9",
+        "updated_at": "2018-12-27",
+        "version": "0.1.0",
         "visit_repo": "https://github.com/custom-cards/vertical-stack-in-card"
     }
 }


### PR DESCRIPTION
According to this https://github.com/custom-cards/vertical-stack-in-card/blob/master/changelog.md#010 the latest version of the card is 0.1.0.